### PR TITLE
[cutes] cutes qtcore.js became qt-core.js

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -17,7 +17,7 @@ var close = function() {
 };
 
 var open = function(fname) {
-    var Q = require('qtcore');
+    var Q = require('qt-core');
     dst = new Q.File(fname);
     if (!dst.open(Q.File.OpenMode.WriteOnly))
         throw {msg: "Can't open output", dst: fname};

--- a/lib/os.js
+++ b/lib/os.js
@@ -35,7 +35,7 @@ error = require('error');
 sys = require('sys');
 _ = require('functional');
 
-var Q = require('qtcore');
+var Q = require('qt-core');
 var string = require('string');
 
 qdir = function(path) {

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -26,7 +26,7 @@ var util = require("util")
 var _fn = require("functional")
 var debug = require("debug")
 var error = require("error")
-var Q = require("qtcore")
+var Q = require("qt-core")
 // debug.level('debug');
 
 var Process = Q.Process;

--- a/lib/time.js
+++ b/lib/time.js
@@ -1,4 +1,4 @@
-var Q = require('qtcore');
+var Q = require('qt-core');
 
 exports.sleep = function(ms) {
     var lock = new Q.Mutex();

--- a/rpm/cutes-js.spec
+++ b/rpm/cutes-js.spec
@@ -8,7 +8,7 @@ URL: https://github.com/nemomobile/cutes-js
 Source0: %{name}-%{version}.tar.bz2
 BuildArch: noarch
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-Requires: cutes >= 0.9.1
+Requires: cutes >= 0.9.11
 Requires: cutes-narwhal = %{version}, cutes-json-js = %{version}
 Requires: coreutils >= 6.9
 BuildRequires: cmake >= 2.8

--- a/tests/test_os.js
+++ b/tests/test_os.js
@@ -150,7 +150,7 @@ fixture.addTest('entryInfoList', function() {
     var f1 = os.path(dirForList, "f1"), f2 = os.path(dirForList, "f2");
 
     var d = os.qt.dir(dirForList);
-    var Q = require('qtcore');
+    var Q = require('qt-core');
     os.write_file(f1, "1");
     var entries = d.entryInfoList(["*"], Q.Dir.Filter.Files, Q.Dir.SortFlag.NoSort);
     test.equal(entries.length, 1);


### PR DESCRIPTION
This is done to avoid conflicts with previous versions of cutes-js
during upgrade

Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
